### PR TITLE
Update to indexByObj functionality

### DIFF
--- a/src/angular-superbox.js
+++ b/src/angular-superbox.js
@@ -34,7 +34,7 @@
 
 		var indexByObj = function(array, obj) {
 			for (var i = 0; i < array.length; i++){
-				if (array[i].id === obj.id)
+				if (angular.equals(array[i], obj))
 					return i;
 			}
 		}

--- a/src/angular-superbox.js
+++ b/src/angular-superbox.js
@@ -26,18 +26,12 @@
           });
         }
 
-        for (var i = 0; i < scope.superboxModel.length; i++) {
-          if (!scope.superboxModel[i].id) {
-            scope.superboxModel[i].id = i;
-          }
-        }
-
-		var indexByObj = function(array, obj) {
-			for (var i = 0; i < array.length; i++){
-				if (angular.equals(array[i], obj))
-					return i;
-			}
+        var indexByObj = function(array, obj) {
+		for (var i = 0; i < array.length; i++){
+			if (angular.equals(array[i], obj))
+				return i;
 		}
+	}
 		
         scope._currentEntry = null;
 


### PR DESCRIPTION
The existing indexByObj functionality depends on the image/photo object to have a unique id field.  This is not documented in the ReadMe but this change will allow the function to work without the "id" field.
